### PR TITLE
fix(onboarding): align company account holder validation

### DIFF
--- a/backend/sellers/services_onboarding.py
+++ b/backend/sellers/services_onboarding.py
@@ -46,6 +46,25 @@ def _is_blank(value: Any) -> bool:
     return value is None or (isinstance(value, str) and value.strip() == "")
 
 
+def _normalize_spaces(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _clean_legal_form(legal_form: str | None) -> str:
+    if _is_blank(legal_form):
+        return ""
+    without_parentheses = re.sub(r"\s*\([^)]*\)", "", legal_form or "")
+    return _normalize_spaces(without_parentheses)
+
+
+def get_expected_company_account_holder(company_name: str | None, legal_form: str | None) -> str:
+    parts = [
+        _normalize_spaces(company_name or ""),
+        _clean_legal_form(legal_form),
+    ]
+    return _normalize_spaces(" ".join(part for part in parts if part))
+
+
 @dataclass
 class Completeness:
     seller_type_selected: bool
@@ -535,7 +554,7 @@ def validate_before_submit(app: SellerOnboardingApplication) -> None:
 
     # account_holder rule from TZ:
     # - self-employed: holder должен совпадать с ФИО
-    # - company: holder должен совпадать с названием компании
+    # - company: holder должен совпадать с названием компании + legal form
     if bank and app.seller_type == SellerType.SELF_EMPLOYED:
         full_name = f"{app.seller_profile.user.first_name} {app.seller_profile.user.last_name}".strip()
         if full_name and bank.account_holder and bank.account_holder.strip() != full_name:
@@ -543,8 +562,13 @@ def validate_before_submit(app: SellerOnboardingApplication) -> None:
 
     if bank and app.seller_type == SellerType.COMPANY:
         ci = getattr(app, "company_info", None)
-        if ci and ci.company_name and bank.account_holder and bank.account_holder.strip() != ci.company_name.strip():
-            errors["account_holder"] = "For company, account holder must match company name."
+        expected_holder = get_expected_company_account_holder(
+            getattr(ci, "company_name", None),
+            getattr(ci, "legal_form", None),
+        ) if ci else ""
+        actual_holder = _normalize_spaces(bank.account_holder or "")
+        if expected_holder and actual_holder and actual_holder != expected_holder:
+            errors["account_holder"] = "For company, account holder must match company name and legal form."
 
     wh = getattr(app, "warehouse_address", None)
     if not wh or _is_blank(wh.street) or _is_blank(wh.city) or _is_blank(wh.zip_code) or _is_blank(wh.country) or _is_blank(wh.contact_phone):

--- a/backend/sellers/tests.py
+++ b/backend/sellers/tests.py
@@ -1,3 +1,68 @@
 from django.test import TestCase
+from rest_framework.exceptions import ValidationError
 
-# Create your tests here.
+from accounts.choices import UserRole
+from accounts.models import CustomUser
+from sellers.models import (
+    SellerBankAccount,
+    SellerCompanyInfo,
+    SellerOnboardingApplication,
+    SellerType,
+)
+from sellers.services_onboarding import (
+    get_expected_company_account_holder,
+    validate_before_submit,
+)
+
+
+class CompanyAccountHolderValidationTests(TestCase):
+    def test_expected_holder_uses_company_name_and_clean_legal_form(self):
+        expected_holder = get_expected_company_account_holder(
+            "Reli",
+            "s.r.o. (Czech Republic / Slovakia)",
+        )
+
+        self.assertEqual(expected_holder, "Reli s.r.o.")
+
+    def test_company_holder_accepts_cleaned_legal_form(self):
+        app = self._create_company_application("Reli s.r.o.")
+
+        try:
+            validate_before_submit(app)
+        except ValidationError as exc:
+            self.assertNotIn("account_holder", exc.detail)
+
+    def test_company_holder_rejects_company_name_without_legal_form(self):
+        app = self._create_company_application("Reli")
+
+        with self.assertRaises(ValidationError) as ctx:
+            validate_before_submit(app)
+
+        self.assertEqual(
+            str(ctx.exception.detail["account_holder"]),
+            "For company, account holder must match company name and legal form.",
+        )
+
+    def _create_company_application(self, account_holder):
+        user = CustomUser.objects.create_user(
+            email="seller@example.com",
+            password="password",
+            role=UserRole.SELLER,
+            first_name="Pavel",
+            last_name="Ivanov",
+        )
+        app = SellerOnboardingApplication.objects.get(seller_profile=user.seller_profile)
+        app.seller_type = SellerType.COMPANY
+        app.save(update_fields=["seller_type"])
+        SellerCompanyInfo.objects.create(
+            application=app,
+            company_name="Reli",
+            legal_form="s.r.o. (Czech Republic / Slovakia)",
+        )
+        SellerBankAccount.objects.create(
+            application=app,
+            iban="CZ94550000000005003011074",
+            swift_bic="RZBCCZPP",
+            account_holder=account_holder,
+        )
+        return app


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes pre-submit onboarding validation for company bank details, which can block legitimate submissions if normalization/format expectations differ from real bank statements. Covered by new unit tests, but still impacts a key business flow.
> 
> **Overview**
> Updates company `account_holder` validation in `validate_before_submit` to require a normalized `company_name` plus a cleaned `legal_form` (parenthetical text removed and whitespace normalized), instead of matching only the raw company name.
> 
> Adds helper utilities (`_normalize_spaces`, `_clean_legal_form`, `get_expected_company_account_holder`) and new tests asserting the expected formatting and that missing legal form in the holder is rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2329c59fce96a05049a2af7c5dafbd85832dc0b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->